### PR TITLE
Add optional Snap to grid for new vertices

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
     <button type="button" id="btn-edit" title="Edit selected polygon (or double-click)">Edit</button>
     <button type="button" id="btn-run">Run covering</button>
     <label>Min square size: <input type="number" id="min-size" min="1" max="200" value="4" /></label>
+    <label><input type="checkbox" id="snap-to-grid" title="Snap new vertices to grid (step = min square size)" /> Snap to grid</label>
     <label>Max k: <input type="number" id="max-k" min="2" max="1024" value="128" title="Max k×k merge (tried by halving: k, k/2, k/4, …)" /></label>
     <label>Min k: <input type="number" id="min-k" min="2" max="1024" value="2" title="Minimum k (halving stops at this)" /></label>
     <label>Speed: <select id="speed-preset" title="Animation step delay"><option value="slow">Slow</option><option value="normal" selected>Normal</option><option value="fast">Fast</option></select></label>

--- a/js/main.js
+++ b/js/main.js
@@ -24,6 +24,7 @@ const btnClear = document.getElementById('btn-clear');
 const btnUndo = document.getElementById('btn-undo');
 const btnRedo = document.getElementById('btn-redo');
 const inputMinSize = document.getElementById('min-size');
+const inputSnapToGrid = document.getElementById('snap-to-grid');
 const inputMaxK = document.getElementById('max-k');
 const inputMinK = document.getElementById('min-k');
 const inputSpeedPreset = document.getElementById('speed-preset');
@@ -193,7 +194,21 @@ function screenToWorld(clientX, clientY) {
   return canvasState.screenToWorld(clientX, clientY);
 }
 
+function snapToGrid(x, y, gridSize) {
+  const step = Math.max(1, gridSize);
+  return {
+    x: Math.round(x / step) * step,
+    y: Math.round(y / step) * step,
+  };
+}
+
 function addPoint(wx, wy) {
+  if (inputSnapToGrid?.checked) {
+    const minSize = Math.max(1, Math.min(500, parseInt(inputMinSize.value, 10) || 8));
+    const snapped = snapToGrid(wx, wy, minSize);
+    wx = snapped.x;
+    wy = snapped.y;
+  }
   if (!state.currentPolygon) state.currentPolygon = [];
   state.currentPolygon.push({ x: wx, y: wy });
   state.undoStack.push({ type: 'add_point', point: { x: wx, y: wy } });
@@ -696,6 +711,9 @@ function loadCoveringPrefs() {
     if (inputInstantRun && typeof prefs.instantRun === 'boolean') {
       inputInstantRun.checked = prefs.instantRun;
     }
+    if (inputSnapToGrid && typeof prefs.snapToGrid === 'boolean') {
+      inputSnapToGrid.checked = prefs.snapToGrid;
+    }
   } catch (_) {}
 }
 function saveCoveringPrefs() {
@@ -703,6 +721,7 @@ function saveCoveringPrefs() {
     const prefs = {
       speed: inputSpeedPreset?.value || 'normal',
       instantRun: inputInstantRun?.checked ?? false,
+      snapToGrid: inputSnapToGrid?.checked ?? false,
     };
     localStorage.setItem(COVERING_PREFS_KEY, JSON.stringify(prefs));
   } catch (_) {}
@@ -710,6 +729,7 @@ function saveCoveringPrefs() {
 loadCoveringPrefs();
 inputSpeedPreset?.addEventListener('change', saveCoveringPrefs);
 inputInstantRun?.addEventListener('change', saveCoveringPrefs);
+inputSnapToGrid?.addEventListener('change', saveCoveringPrefs);
 
 canvasState.resize();
 draw();


### PR DESCRIPTION
Implements the fix plan from #6.

**Changes:**
- **index.html**: Added "Snap to grid" checkbox next to Min square size (tooltip: step = min square size).
- **main.js**:
  - `snapToGrid(x, y, gridSize)`: snaps to grid with origin (0,0), step = `Math.max(1, gridSize)`.
  - `addPoint(wx, wy)`: when snap is enabled, reads min size (clamp 1–500, default 8), snaps coordinates, then adds point and undo entry as before.
  - Snap preference persisted in `COVERING_PREFS_KEY` (load/save + change listener).

**Behavior:**
- Only when the checkbox is on do new vertices (draw and edit mode) snap to multiples of the current min square size.
- Undo/redo and export/import unchanged; stored points are the snapped coordinates when snap was on.
- No changes to `drawing.js` or `covering.js`.

Closes #6.