### PR TITLE
Display polygon area, covered area, and efficiency

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,6 +143,7 @@
     <label>Speed: <select id="speed-preset" title="Animation step delay"><option value="slow">Slow</option><option value="normal" selected>Normal</option><option value="fast">Fast</option></select></label>
     <label><input type="checkbox" id="instant-run" title="Run to completion without animation" /> Run without animation</label>
     <span id="square-count">Squares: —  ·  Iterations: —</span>
+    <span id="stats-area" title="Polygon union area, covered rectangle area, area per square (units²)">Polygon area: —  ·  Covered area: —  ·  Efficiency: —</span>
     <div class="dropdown" id="export-dropdown">
       <button type="button" id="btn-export">Export ▾</button>
       <div class="dropdown-content">

--- a/js/covering.js
+++ b/js/covering.js
@@ -244,3 +244,25 @@ function signedArea(pts) {
   }
   return a / 2;
 }
+
+/** Area of one region: exterior ring area minus hole areas. Region may be { exterior, holes } or a single ring (points). */
+function regionArea(region) {
+  if (!region) return 0;
+  const exterior = region.exterior != null ? region.exterior : region;
+  const holes = Array.isArray(region) ? [] : (region.holes || []);
+  let a = Math.abs(signedArea(exterior));
+  for (const h of holes) {
+    a -= Math.abs(signedArea(h));
+  }
+  return Math.max(0, a);
+}
+
+/**
+ * Total area of the union of the given polygons (world square units).
+ * Uses the same union + per-ring signed area as the covering. Returns 0 if no polygons.
+ */
+export function getUnionArea(polygonList) {
+  const regions = unionPolygons(polygonList);
+  if (!regions || regions.length === 0) return 0;
+  return regions.reduce((sum, reg) => sum + regionArea(reg), 0);
+}


### PR DESCRIPTION
Implements the fix plan from #11.

**Changes:**
- **covering.js**: Added `getUnionArea(polygonList)` that computes total area of the union using existing `unionPolygons` + per-region signed area (exterior minus holes). Returns 0 when no polygons.
- **main.js**: Import `getUnionArea`. Added `getCoveredArea(rectangles)` (sum of `w×h`), `getPolygonListForArea()` (closed polygons + current if ≥3 points), and `updateStats()` which updates the new stats element with polygon area, covered area, and efficiency (polygon area per square). Stats run from `draw()` so they stay in sync on any polygon/rectangle change.
- **index.html**: Added `#stats-area` span in the toolbar showing "Polygon area: … · Covered area: … · Efficiency: …" with units²; shows "—" when no polygons or no rectangles.

**Edge cases:** No polygons → "—"; polygons but no run → polygon area only; efficiency = polygon area / square count when count > 0, else "—".

Closes #11.