### PR TITLE
Show coverage % in stats footer (fixes #36)

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@
     <label>Speed: <select id="speed-preset" title="Animation step delay"><option value="slow">Slow</option><option value="normal" selected>Normal</option><option value="fast">Fast</option></select></label>
     <label><input type="checkbox" id="instant-run" title="Run to completion without animation" /> Run without animation</label>
     <span id="square-count">Squares: —  ·  Iterations: —</span>
-    <span id="stats-area" title="Polygon union area, covered rectangle area, area per square (units²)">Polygon area: —  ·  Covered area: —  ·  Efficiency: —</span>
+    <span id="stats-area" title="Polygon union area, covered rectangle area, area per square (units²), coverage: % of polygon covered by squares">Polygon area: —  ·  Covered area: —  ·  Efficiency: —</span>
   </div>
   <div id="toast" aria-live="polite"></div>
   <div id="canvas-wrap">

--- a/js/main.js
+++ b/js/main.js
@@ -241,10 +241,17 @@ function updateStats() {
   const n = state.rectangles.length;
   const efficiency = n > 0 && polygonArea != null ? polygonArea / n : null;
 
+  const coveragePct =
+    polygonArea != null && polygonArea > 0 && coveredArea != null
+      ? (coveredArea / polygonArea) * 100
+      : null;
+  const coverageStr =
+    coveragePct != null ? `${coveragePct.toFixed(1)}% coverage` : 'Coverage: —';
+
   const paStr = polygonArea != null ? polygonArea.toFixed(1) + ' units²' : '—';
   const caStr = coveredArea != null ? coveredArea.toFixed(1) + ' units²' : '—';
   const effStr = efficiency != null ? efficiency.toFixed(1) + ' units²/square' : '—';
-  statsAreaEl.textContent = `Polygon area: ${paStr}  ·  Covered area: ${caStr}  ·  Efficiency: ${effStr}`;
+  statsAreaEl.textContent = `Polygon area: ${paStr}  ·  Covered area: ${caStr}  ·  Efficiency: ${effStr}  ·  ${coverageStr}`;
 }
 
 function draw() {


### PR DESCRIPTION
## Summary
Implements the fix described in issue #36: show what percentage of the polygon is covered by the squares in the footer stats.

## Changes
- **js/main.js**: In `updateStats()`, compute coverage % = `(coveredArea / polygonArea) * 100` when both polygon area and covered area are available. Display as `X.X% coverage` or `Coverage: —` when there is no polygon or no rectangles. Appended to the existing stats line with the same separator style.
- **index.html**: Updated `#stats-area` `title` to include "coverage: % of polygon covered by squares".

## Testing
- No polygon → coverage shows `—`
- Polygon but no rectangles yet → coverage shows `—`
- After running covering, footer shows e.g. `98.5% coverage` (≤ 100%)

Closes #36